### PR TITLE
feat: add debounced repo search with loading spinner to clone dialog

### DIFF
--- a/src/app/_client/components/ui/Spinner.tsx
+++ b/src/app/_client/components/ui/Spinner.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+
+export interface SpinnerProps {
+  size?: 'sm' | 'md' | 'lg'
+  className?: string
+}
+
+export const Spinner = ({ size = 'md', className = '' }: SpinnerProps) => {
+  const sizeClasses = {
+    sm: 'w-4 h-4',
+    md: 'w-6 h-6',
+    lg: 'w-8 h-8'
+  }
+
+  return (
+    <div 
+      className={`animate-spin rounded-full border-2 border-gray-300 border-t-blue-600 ${sizeClasses[size]} ${className}`}
+      role="status"
+      aria-label="Loading..."
+    />
+  )
+}


### PR DESCRIPTION
- Add 800ms debounce delay to prevent excessive GitHub API calls during typing
- Display loading spinner with "Finding repository..." message during validation
- Remove onBlur trigger - validation now happens automatically on URL change
- Add proper loading state management to prevent duplicate submissions
- Create reusable Spinner component with size variants and accessibility
- Fix circular dependency between updateUrl and validateUrl functions
- Add cleanup effect for debounce timer on component unmount
- Update input disabled state to include loading condition

The implementation provides a smoother user experience by eliminating the need to tab out of the input field while providing visual feedback during repository validation.